### PR TITLE
feat: enable to specify date in contents with values (notion)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,2 @@
 [flake8]
-ignore = E226,E302,E41
 max-line-length = 160

--- a/examples/create_notion_page_from_template_with_value_content.py
+++ b/examples/create_notion_page_from_template_with_value_content.py
@@ -1,0 +1,23 @@
+from autonote.notion import NotionClient
+
+client = NotionClient()
+
+kwargs = {
+    "Date": {"start": "2023-02-04", "end": "2023-02-10"},
+    "replace_rules": [
+        {
+            "block_types": ["heading_1"],
+            "replace_str": "YYYY/MM/DD",
+            "replace_type": "datetime",
+            "date_format": "%Y/%m/%d",
+            "start_date": "2023/02/04",
+            "increment": True,
+        },
+    ],
+}
+client.create_page_from_template(
+    template_id="a7cc4f73460c4b9fa82be8d4ed74d8ca",
+    title="weekly note",
+    override=True,
+    **kwargs
+)

--- a/examples/create_notion_page_from_template_with_value_content.py
+++ b/examples/create_notion_page_from_template_with_value_content.py
@@ -6,12 +6,12 @@ kwargs = {
     "Date": {"start": "2023-02-04", "end": "2023-02-10"},
     "replace_rules": [
         {
-            "block_types": ["heading_1"],
-            "replace_str": "YYYY/MM/DD",
-            "replace_type": "datetime",
-            "date_format": "%Y/%m/%d",
-            "start_date": "2023/02/04",
-            "increment": True,
+            "block_types": ["heading_1"],  # target blocks to apply replacement
+            "replace_str": "YYYY/MM/DD",  # replacement string match
+            "replace_type": "datetime",  # currently only support "datetime"
+            "date_format": "%Y/%m/%d",  # used to parse `start_date` and generate string from datetime when interpolating
+            "start_date": "2023/02/04",  # start date
+            "increment": True,  # if true, increment 1 day every time replacement is executed
         },
     ],
 }

--- a/src/autonote/notion.py
+++ b/src/autonote/notion.py
@@ -111,16 +111,18 @@ class NotionPageContent:
         """Update contents with contents and **kwargs
 
         Args:
-            contents (dict): blocks that are returned from blocks.children.list["result"]
+            contents (list): list of dict that contains type and the value e.g.
+                {'type': 'table_of_contents', 'table_of_contents': {'color': 'gray'}}
+                blocks that are returned from blocks.children.list["result"]
             kwargs (dict): you can pass replacement rule for the content.
+
+        Example of contents:
+        [{'type': 'table_of_contents', 'table_of_contents': {'color': 'gray'}}
+        {'type': 'heading_1', 'heading_1': {'rich_text': [{'type': 'text', 'text':...
+        {'type': 'numbered_list_item', 'numbered_list_item': {'rich_text': [], 'color': 'default'}}
+        {'type': 'paragraph', 'paragraph': {'rich_text': [], 'color': 'default'}}]
         """
-        self.contents = [
-            {
-                "type": blk["type"],
-                blk["type"]: blk[blk["type"]],
-            }
-            for blk in contents
-        ]
+        self.contents = contents
         for e in self.contents:
             print(e)
 

--- a/tests/test_notion.py
+++ b/tests/test_notion.py
@@ -1,4 +1,11 @@
+import pytest
+
 from autonote.notion import NotionPage, NotionPageContent
+
+
+def test_notion_page_parent_type():
+    with pytest.raises(ValueError):
+        NotionPage(title="test", parent_type="invalid")
 
 
 def test_notion_page_simple_database():

--- a/tests/test_notion.py
+++ b/tests/test_notion.py
@@ -1,4 +1,4 @@
-from autonote.notion import NotionPage
+from autonote.notion import NotionPage, NotionPageContent
 
 
 def test_notion_page_simple_database():
@@ -180,3 +180,50 @@ def test_notion_page_update_template_property_with_nonexisting_value():
     assert page.properties == {
         "title": [{"type": "text", "text": {"content": "test title"}}],
     }
+
+
+def test_notion_page_content_from_body():
+    content = NotionPageContent("body")
+    assert content.contents == [
+        {
+            "object": "block",
+            "type": "heading_2",
+            "heading_2": {"rich_text": [{"type": "text", "text": {"content": "body"}}]},
+        }
+    ]
+
+
+def test_notion_page_content_update_contents():
+    contents = [
+        {"type": "table_of_contents", "table_of_contents": {"color": "gray"}},
+        {
+            "type": "heading_1",
+            "heading_1": {
+                "rich_text": [
+                    {
+                        "type": "text",
+                        "text": {"content": "YYYY/MM/DD (月)", "link": None},
+                        "annotations": {
+                            "bold": False,
+                            "italic": False,
+                            "strikethrough": False,
+                            "underline": False,
+                            "code": False,
+                            "color": "default",
+                        },
+                        "plain_text": "YYYY/MM/DD (月)",
+                        "href": None,
+                    }
+                ],
+                "is_toggleable": False,
+                "color": "default",
+            },
+        },
+        {
+            "type": "numbered_list_item",
+            "numbered_list_item": {"rich_text": [], "color": "default"},
+        },
+        {"type": "paragraph", "paragraph": {"rich_text": [], "color": "default"}},
+    ]
+    content = NotionPageContent("body", contents=contents)
+    assert content.contents == contents

--- a/tests/test_notion.py
+++ b/tests/test_notion.py
@@ -234,3 +234,55 @@ def test_notion_page_content_update_contents():
     ]
     content = NotionPageContent("body", contents=contents)
     assert content.contents == contents
+
+
+def test_notion_page_content_update_contents():
+    contents = [
+        {"type": "table_of_contents", "table_of_contents": {"color": "gray"}},
+        {
+            "type": "numbered_list_item",
+            "numbered_list_item": {"rich_text": [], "color": "default"},
+        },
+        {
+            "type": "heading_1",
+            "heading_1": {
+                "rich_text": [
+                    {
+                        "type": "text",
+                        "text": {"content": "YYYY/MM/DD (月)", "link": None},
+                        "annotations": {
+                            "bold": False,
+                            "italic": False,
+                            "strikethrough": False,
+                            "underline": False,
+                            "code": False,
+                            "color": "default",
+                        },
+                        "plain_text": "YYYY/MM/DD (月)",
+                        "href": None,
+                    }
+                ],
+                "is_toggleable": False,
+                "color": "default",
+            },
+        },
+    ]
+    replace_rules = [
+        {
+            "replace_type": "datetime",
+            "block_types": "heading_1",
+            "replace_str": "YYYY/MM/DD",
+            "date_format": "%Y-%m-%d",
+            "start_date": "2023-01-01",
+        }
+    ]
+    content = NotionPageContent("body", contents=contents, replace_rules=replace_rules)
+    print(contents)
+    assert (
+        content.contents[2]["heading_1"]["rich_text"][0]["text"]["content"]
+        == "2023-01-01 (月)"
+    )
+    assert (
+        content.contents[2]["heading_1"]["rich_text"][0]["plain_text"]
+        == "2023-01-01 (月)"
+    )

--- a/tests/test_notion.py
+++ b/tests/test_notion.py
@@ -236,7 +236,7 @@ def test_notion_page_content_update_contents():
     assert content.contents == contents
 
 
-def test_notion_page_content_update_contents():
+def test_notion_page_content_update_contents_replace_datetime():
     contents = [
         {"type": "table_of_contents", "table_of_contents": {"color": "gray"}},
         {
@@ -277,7 +277,6 @@ def test_notion_page_content_update_contents():
         }
     ]
     content = NotionPageContent("body", contents=contents, replace_rules=replace_rules)
-    print(contents)
     assert (
         content.contents[2]["heading_1"]["rich_text"][0]["text"]["content"]
         == "2023-01-01 (月)"

--- a/tests/test_notion.py
+++ b/tests/test_notion.py
@@ -2,24 +2,15 @@ from autonote.notion import NotionPage
 
 
 def test_notion_page_simple_database():
-    page = NotionPage(title="test title", body="test body")
-    kwargs = page.database_content(parent_database_id="parent_database_id")
-    assert kwargs["parent"] == {
-        "type": "database_id",
-        "database_id": "parent_database_id",
-    }
-    assert kwargs["properties"] == {
-        "title": [{"type": "text", "text": {"content": "test title"}}]
-    }
-    assert kwargs["contents"] == [
-        {
-            "object": "block",
-            "type": "heading_2",
-            "heading_2": {
-                "rich_text": [{"type": "text", "text": {"content": "test body"}}]
-            },
+    page = NotionPage(title="test title", parent_type="database_id")
+    kwargs = page.pages_kwargs(parent_id="parent_database_id")
+    assert kwargs == {
+        "parent": {
+            "type": "database_id",
+            "database_id": "parent_database_id",
         },
-    ]
+        "properties": {"title": [{"type": "text", "text": {"content": "test title"}}]},
+    }
 
 
 def test_notion_page_with_properties_tag():
@@ -36,7 +27,7 @@ def test_notion_page_with_properties_tag():
             ],
         },
     }
-    page = NotionPage(title="test title", body="test body")
+    page = NotionPage(title="test title", parent_type="page_id")
     page.update_properties(properties=properties)
     assert page.properties == {
         "title": [{"type": "text", "text": {"content": "test title"}}],
@@ -49,7 +40,7 @@ def test_notion_page_with_properties_tag():
         ],
     }
 
-    page = NotionPage(title="test title", body="test body", properties=properties)
+    page = NotionPage(title="test title", parent_type="page_id", properties=properties)
     assert page.properties == {
         "title": [{"type": "text", "text": {"content": "test title"}}],
         "Tags": [
@@ -70,14 +61,14 @@ def test_notion_page_with_properties_date():
             "date": {"start": "2023-02-04", "end": "2023-02-10", "time_zone": None},
         }
     }
-    page = NotionPage(title="test title", body="test body")
+    page = NotionPage(title="test title", parent_type="page_id")
     page.update_properties(properties=properties)
     assert page.properties == {
         "title": [{"type": "text", "text": {"content": "test title"}}],
         "Start Date": {"start": "2023-02-04", "end": "2023-02-10", "time_zone": None},
     }
 
-    page = NotionPage(title="test title", body="test body", properties=properties)
+    page = NotionPage(title="test title", parent_type="page_id", properties=properties)
     assert page.properties == {
         "title": [{"type": "text", "text": {"content": "test title"}}],
         "Start Date": {"start": "2023-02-04", "end": "2023-02-10", "time_zone": None},
@@ -96,7 +87,7 @@ def test_notion_page_with_properties_select():
             },
         }
     }
-    page = NotionPage(title="test title", body="test body", properties=properties)
+    page = NotionPage(title="test title", parent_type="page_id", properties=properties)
     assert page.properties == {
         "title": [{"type": "text", "text": {"content": "test title"}}],
         "Size": {
@@ -115,14 +106,14 @@ def test_notion_page_with_properties_empty():
             "date": None,
         }
     }
-    page = NotionPage(title="test title", body="test body")
+    page = NotionPage(title="test title", parent_type="page_id")
     page.update_properties(properties=properties)
     assert page.properties == {
         "title": [{"type": "text", "text": {"content": "test title"}}],
         "Start Date": None,
     }
 
-    page = NotionPage(title="test title", body="test body", properties=properties)
+    page = NotionPage(title="test title", parent_type="page_id", properties=properties)
     assert page.properties == {
         "title": [{"type": "text", "text": {"content": "test title"}}],
         "Start Date": None,
@@ -137,13 +128,13 @@ def test_notion_page_cannot_update_title():
             "title": [{"type": "text", "text": {"content": "OKR template"}}],
         }
     }
-    page = NotionPage(title="test title", body="test body")
+    page = NotionPage(title="test title", parent_type="page_id")
     page.update_properties(properties=properties)
     assert page.properties["title"] == [
         {"type": "text", "text": {"content": "test title"}}
     ]
 
-    page = NotionPage(title="test title", body="test body", properties=properties)
+    page = NotionPage(title="test title", parent_type="page_id", properties=properties)
     assert page.properties["title"] == [
         {"type": "text", "text": {"content": "test title"}}
     ]
@@ -158,7 +149,9 @@ def test_notion_page_update_template_property_with_value_date():
         }
     }
     kwargs = {"Start Date": {"start": "2023-02-04", "end": "2023-02-10"}}
-    page = NotionPage(title="test", body="test", properties=properties, **kwargs)
+    page = NotionPage(
+        title="test", parent_type="page_id", properties=properties, **kwargs
+    )
     assert page.properties["Start Date"] == {
         "start": "2023-02-04",
         "end": "2023-02-10",
@@ -175,13 +168,15 @@ def test_notion_page_update_none_template_property_with_value_date():
         }
     }
     kwargs = {"Start Date": {"start": "2023-02-04", "end": "2023-02-10"}}
-    page = NotionPage(title="test", body="test", properties=properties, **kwargs)
+    page = NotionPage(
+        title="test", parent_type="page_id", properties=properties, **kwargs
+    )
     assert page.properties["Start Date"] == {"start": "2023-02-04", "end": "2023-02-10"}
 
 
 def test_notion_page_update_template_property_with_nonexisting_value():
     kwargs = {"nonexisting key": {"start": "2023-02-04", "end": "2023-02-10"}}
-    page = NotionPage(title="test title", body="test", **kwargs)
+    page = NotionPage(title="test title", parent_type="page_id", **kwargs)
     assert page.properties == {
         "title": [{"type": "text", "text": {"content": "test title"}}],
     }


### PR DESCRIPTION
- Enable to specify date in contents with values

    Example: Replace `YYYY/MM/DD` in the template with actual date starting from `2023/02/04`

    ```py
    from autonote.notion import NotionClient
    
    client = NotionClient()
    
    kwargs = {
        "Date": {"start": "2023-02-04", "end": "2023-02-10"},
        "replace_rules": [
            {
                "block_types": ["heading_1"], # target blocks to apply replacement
                "replace_str": "YYYY/MM/DD", # replacement string match 
                "replace_type": "datetime", # currently only support "datetime"
                "date_format": "%Y/%m/%d", # used to parse `start_date` and generate string from datetime when interpolating
                "start_date": "2023/02/04", # start date
                "increment": True, # if true, increment 1 day every time replacement is executed
            },
        ],
    }
    client.create_page_from_template(
        template_id="a7cc4f73460c4b9fa82be8d4ed74d8ca",
        title="weekly note",
        override=True,
        **kwargs
    )
    ```

2. Update .flake8 rule.

    ```
    flake8 --help
    ...
      --ignore errors       Comma-separated list of error codes to ignore (or skip). For example,
                            ``--ignore=E4,E51,W234``. (Default: E121,E123,E126,E226,E24,E704,W503,W504)
    ```

    W503 appears as it wasn't ignored. https://github.com/psf/black/blob/main/docs/guides/using_black_with_other_tools.md#why-those-options-above-1
    we might need to add `extend-ignore: E203` in the future.
