### PR TITLE
chore: use trusted publisher for pypi in release.yml

### DIFF
--- a/.github/workflows/replease.yml
+++ b/.github/workflows/replease.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/
+          repository-url: https://test.pypi.org/legacy/
 
       - name: Test install from TestPyPI
         run: |

--- a/.github/workflows/replease.yml
+++ b/.github/workflows/replease.yml
@@ -1,4 +1,4 @@
-name: release
+name: release # you cannot change this workflow name as it's used for trusted publisher
 
 on:
   workflow_dispatch:
@@ -8,7 +8,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     environment:
       name: pypi
-      url: https://pypi.org/p/<your-pypi-project-name>
+      url: https://pypi.org/p/autonote
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     runs-on: ubuntu-latest

--- a/.github/workflows/replease.yml
+++ b/.github/workflows/replease.yml
@@ -6,6 +6,11 @@ on:
 jobs:
   releaase:
     if: github.ref == 'refs/heads/main'
+    environment:
+      name: pypi
+      url: https://pypi.org/p/<your-pypi-project-name>
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     runs-on: ubuntu-latest
     steps:
       - name: Set up Python
@@ -52,8 +57,6 @@ jobs:
       - name: Publish to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
 
       - name: Test install from TestPyPI
@@ -65,6 +68,3 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
https://github.com/pypa/gh-action-pypi-publish

use trusted publisher

https://docs.pypi.org/trusted-publishers/adding-a-publisher/