### PR TITLE
chore: remove build command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.semantic_release]
 version_variables = ["pyproject.toml:version"] # version location
-build_command = "poetry build"              # build dists
 dist_path = "dist/"                         # where to put dists
 remove_dist = false                         # don't remove dists
 assets = []


### PR DESCRIPTION
```
Error: Command '['bash', '-c', 'poetry build']' returned non-zero exit status 127.
```