### PR TITLE
chore: prerelease 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,347 @@
-# Changelog
+# CHANGELOG
 
-<!--next-version-placeholder-->
 
-## 0.1.3 (2023/01/05)
 
-- Enable to release by [python-semantic-release (PSR)](https://github.com/python-semantic-release/python-semantic-release)
+## v0.5.0-rc.1+release-prepare (2023-08-27)
 
-## 0.1.2 (2023/01/04)
+### Chore
 
-- First release of `autonote`!
+* chore: update build command (#80) ([`9c5d160`](https://github.com/nakamasato/autodoc/commit/9c5d1600651905a1d66bd6dc5ad69e5f97bb3f08))
+
+* chore: remove build command (#79) ([`0d7d2ce`](https://github.com/nakamasato/autodoc/commit/0d7d2ce1393fa165c3dc0ed9fd13c2b4dca40446))
+
+* chore: replace release step with python-semantic-release (#78) ([`0725a72`](https://github.com/nakamasato/autodoc/commit/0725a7282464f2b70585400bd2e994d21f1047d0))
+
+* chore: upgrade configuration for semantic-release (#77) ([`25c4d4f`](https://github.com/nakamasato/autodoc/commit/25c4d4f99908b573222dbc84ebc6a54aebbb70b5))
+
+* chore(deps): update dependency python-semantic-release to v8.0.8 (#76)
+
+Co-authored-by: renovate[bot] &lt;29139614+renovate[bot]@users.noreply.github.com&gt; ([`907f294`](https://github.com/nakamasato/autodoc/commit/907f29401f1676403cd365b51bfa698659dad4bc))
+
+* chore: fix typo release.yml (#75) ([`2966bc2`](https://github.com/nakamasato/autodoc/commit/2966bc20f8a9f0fa04e8f1de68df078764fad78e))
+
+* chore: update CONTRIBUTING.md (#74) ([`038ff2a`](https://github.com/nakamasato/autodoc/commit/038ff2a3ad01a5c46ffd03efcda7ea253ba83bcf))
+
+* chore: rename replease.yml to release.yml (#73) ([`03ec634`](https://github.com/nakamasato/autodoc/commit/03ec634f2ea948fbe4149ea495368164416d43bd))
+
+* chore: use trusted publisher for pypi in release.yml (#72) ([`94189a0`](https://github.com/nakamasato/autodoc/commit/94189a0b6ef6ff56ce9dc1d5899b8a1bf9d65103))
+
+* chore: skip formula properties from template (#71) ([`48e72dd`](https://github.com/nakamasato/autodoc/commit/48e72dde11ab2099d25a32bcec9474966e3ed9ff))
+
+* chore: add e2e with demo token (#69) ([`5018988`](https://github.com/nakamasato/autodoc/commit/501898829ded52052af2a32a8aff2b0183180046))
+
+* chore(deps): update dependency sphinx-rtd-theme to v1.3.0 (#68)
+
+Co-authored-by: renovate[bot] &lt;29139614+renovate[bot]@users.noreply.github.com&gt; ([`966f2e9`](https://github.com/nakamasato/autodoc/commit/966f2e9b707f0563f496ca8c991c1f8b2215527d))
+
+* chore(deps): update dependency python-semantic-release to v8.0.7 (#66)
+
+Co-authored-by: renovate[bot] &lt;29139614+renovate[bot]@users.noreply.github.com&gt; ([`73fbe05`](https://github.com/nakamasato/autodoc/commit/73fbe0574c940338d725bf04acda40f0bf252c38))
+
+* chore(deps): update dependency python-semantic-release to v8.0.6 (#65)
+
+Co-authored-by: renovate[bot] &lt;29139614+renovate[bot]@users.noreply.github.com&gt; ([`0d3e2ff`](https://github.com/nakamasato/autodoc/commit/0d3e2ff9a396eb0426fe26f77b2f115bdfd7da73))
+
+* chore(deps): update dependency python-semantic-release to v8.0.5 (#63)
+
+Co-authored-by: renovate[bot] &lt;29139614+renovate[bot]@users.noreply.github.com&gt; ([`188067a`](https://github.com/nakamasato/autodoc/commit/188067a28648be57d06ddf47e97c30980cf04286))
+
+* chore(deps): update dependency flake8 to v6.1.0 (#62)
+
+Co-authored-by: renovate[bot] &lt;29139614+renovate[bot]@users.noreply.github.com&gt; ([`5a27f72`](https://github.com/nakamasato/autodoc/commit/5a27f729be1a5cf5186cde6f433c785c37ac8c3b))
+
+* chore(deps): update dependency python-semantic-release to v8.0.4 (#60)
+
+Co-authored-by: renovate[bot] &lt;29139614+renovate[bot]@users.noreply.github.com&gt; ([`d268b8b`](https://github.com/nakamasato/autodoc/commit/d268b8bf9335fadb8a35a7288b7c204025fa8336))
+
+* chore(deps): update dependency python-semantic-release to v8.0.3 (#59)
+
+Co-authored-by: renovate[bot] &lt;29139614+renovate[bot]@users.noreply.github.com&gt; ([`8d72da0`](https://github.com/nakamasato/autodoc/commit/8d72da0f0dccb3c726d953c329796505155348a2))
+
+* chore(deps): update dependency python-semantic-release to v8.0.2 (#58)
+
+Co-authored-by: renovate[bot] &lt;29139614+renovate[bot]@users.noreply.github.com&gt; ([`b2f3073`](https://github.com/nakamasato/autodoc/commit/b2f3073cc1536ad96532a5be7183e8137a7927be))
+
+* chore(deps): update dependency python-semantic-release to v8.0.1 (#57)
+
+Co-authored-by: renovate[bot] &lt;29139614+renovate[bot]@users.noreply.github.com&gt; ([`ae84929`](https://github.com/nakamasato/autodoc/commit/ae84929708be8150c841dcade622d05df7d89c85))
+
+* chore(deps): update dependency python-semantic-release to v8 (#56)
+
+Co-authored-by: renovate[bot] &lt;29139614+renovate[bot]@users.noreply.github.com&gt; ([`76efd4d`](https://github.com/nakamasato/autodoc/commit/76efd4d189d9920434153b8641d9339ff0880263))
+
+* chore(deps): update dependency black to v23.7.0 (#55)
+
+Co-authored-by: renovate[bot] &lt;29139614+renovate[bot]@users.noreply.github.com&gt; ([`a8ddfd4`](https://github.com/nakamasato/autodoc/commit/a8ddfd4753943711d01f8eef636d839a5a58123f))
+
+* chore(deps): update dependency pytest to v7.4.0 (#54)
+
+Co-authored-by: renovate[bot] &lt;29139614+renovate[bot]@users.noreply.github.com&gt; ([`b362da0`](https://github.com/nakamasato/autodoc/commit/b362da000a3aecaa2f89faf208bdbb5a5f41feae))
+
+* chore(deps): update dependency python-semantic-release to v7.34.6 (#52)
+
+Co-authored-by: renovate[bot] &lt;29139614+renovate[bot]@users.noreply.github.com&gt; ([`041113e`](https://github.com/nakamasato/autodoc/commit/041113ed1d4f9044f74d9621eb4297407db3c8a3))
+
+* chore(deps): update dependency python-semantic-release to v7.34.4 (#51)
+
+Co-authored-by: renovate[bot] &lt;29139614+renovate[bot]@users.noreply.github.com&gt; ([`f675cd3`](https://github.com/nakamasato/autodoc/commit/f675cd39d7b4aaf437b5df2440a6753ace06afc9))
+
+* chore(deps): update dependency pytest to v7.3.2 (#50)
+
+Co-authored-by: renovate[bot] &lt;29139614+renovate[bot]@users.noreply.github.com&gt; ([`c4a8f45`](https://github.com/nakamasato/autodoc/commit/c4a8f45e4affef1ea69cc00fc0850f8af386499f))
+
+* chore(deps): update dependency sphinx-autoapi to v2.1.1 (#49)
+
+Co-authored-by: renovate[bot] &lt;29139614+renovate[bot]@users.noreply.github.com&gt; ([`418ab2c`](https://github.com/nakamasato/autodoc/commit/418ab2c064b2fdb9c06207150ae20a167654cf5d))
+
+* chore(deps): update dependency sphinx-rtd-theme to v1.2.2 (#48)
+
+Co-authored-by: renovate[bot] &lt;29139614+renovate[bot]@users.noreply.github.com&gt; ([`01b21e9`](https://github.com/nakamasato/autodoc/commit/01b21e94aa80dc39334df83315781bfec4e7efbe))
+
+* chore(deps): update dependency python-semantic-release to v7.34.3 (#47)
+
+Co-authored-by: renovate[bot] &lt;29139614+renovate[bot]@users.noreply.github.com&gt; ([`9624a0a`](https://github.com/nakamasato/autodoc/commit/9624a0a32044d2fd5d435666e800d4a6156494fe))
+
+* chore(deps): update dependency python-semantic-release to v7.34.2 (#46)
+
+Co-authored-by: renovate[bot] &lt;29139614+renovate[bot]@users.noreply.github.com&gt; ([`3bde466`](https://github.com/nakamasato/autodoc/commit/3bde4664f78a7fbc37df28296b4487b0010b71d8))
+
+* chore(deps): update dependency python-semantic-release to v7.34.1 (#44)
+
+Co-authored-by: renovate[bot] &lt;29139614+renovate[bot]@users.noreply.github.com&gt; ([`b767852`](https://github.com/nakamasato/autodoc/commit/b767852683e2d4dc165ebdc25a7743a1a75df84a))
+
+* chore(deps): update dependency python-semantic-release to v7.34.0 (#43)
+
+Co-authored-by: renovate[bot] &lt;29139614+renovate[bot]@users.noreply.github.com&gt; ([`7a33dd6`](https://github.com/nakamasato/autodoc/commit/7a33dd6299e766214e8c303024656782c40688e2))
+
+* chore(deps): update dependency pytest-cov to v4.1.0 (#42)
+
+Co-authored-by: renovate[bot] &lt;29139614+renovate[bot]@users.noreply.github.com&gt; ([`21a901a`](https://github.com/nakamasato/autodoc/commit/21a901add0c4dfea3c5e4dace2928e69f8ce9da3))
+
+* chore(deps): update dependency sphinx-rtd-theme to v1.2.1 (#41)
+
+Co-authored-by: renovate[bot] &lt;29139614+renovate[bot]@users.noreply.github.com&gt; ([`75ad234`](https://github.com/nakamasato/autodoc/commit/75ad234e0915df3d2ec44d12caafce7c4d1ccb22))
+
+* chore(deps): update dependency python-semantic-release to v7.33.5 (#40)
+
+Co-authored-by: renovate[bot] &lt;29139614+renovate[bot]@users.noreply.github.com&gt; ([`353b0b8`](https://github.com/nakamasato/autodoc/commit/353b0b8c800b130ca5549b2a8cd3f7cc0ab48055))
+
+* chore(deps): update dependency python-semantic-release to v7.33.4 (#38)
+
+Co-authored-by: renovate[bot] &lt;29139614+renovate[bot]@users.noreply.github.com&gt; ([`e399869`](https://github.com/nakamasato/autodoc/commit/e39986927beb16c63c08f0c51570581b9a74d8cd))
+
+* chore(deps): update dependency python-semantic-release to v7.33.3 (#37)
+
+Co-authored-by: renovate[bot] &lt;29139614+renovate[bot]@users.noreply.github.com&gt; ([`12f3d58`](https://github.com/nakamasato/autodoc/commit/12f3d586420078195bc1c9bf1c72c37b477ac8eb))
+
+* chore(deps): update dependency myst-nb to v0.17.2 (#36)
+
+Co-authored-by: renovate[bot] &lt;29139614+renovate[bot]@users.noreply.github.com&gt; ([`8052f08`](https://github.com/nakamasato/autodoc/commit/8052f08a2849499a064c5e325ad17a168c5af7ed))
+
+* chore(deps): update dependency python-dotenv to v1 (#26)
+
+Co-authored-by: renovate[bot] &lt;29139614+renovate[bot]@users.noreply.github.com&gt; ([`cf98453`](https://github.com/nakamasato/autodoc/commit/cf984537367f64a3559ad2cd8eaf820574166d1e))
+
+* chore(deps): update dependency sphinx-rtd-theme to v1.2.0 (#32)
+
+Co-authored-by: renovate[bot] &lt;29139614+renovate[bot]@users.noreply.github.com&gt; ([`04dfee3`](https://github.com/nakamasato/autodoc/commit/04dfee38c91883a26d340a9c9714992756b6b753))
+
+* chore(deps): update dependency sphinx-autoapi to v2.1.0 (#29)
+
+Co-authored-by: renovate[bot] &lt;29139614+renovate[bot]@users.noreply.github.com&gt; ([`e54d556`](https://github.com/nakamasato/autodoc/commit/e54d556b1254881c88e6ba593ea535f27fcfd8f6))
+
+* chore(deps): update dependency python-semantic-release to v7.33.2 (#31)
+
+Co-authored-by: renovate[bot] &lt;29139614+renovate[bot]@users.noreply.github.com&gt; ([`a0271ea`](https://github.com/nakamasato/autodoc/commit/a0271eaa5becd36cc613d7a2c7bd1acf8f5bab4a))
+
+* chore(deps): update dependency pytest to v7.3.1 (#27)
+
+Co-authored-by: renovate[bot] &lt;29139614+renovate[bot]@users.noreply.github.com&gt; ([`b0bf185`](https://github.com/nakamasato/autodoc/commit/b0bf185bd222c07eb85b321e3a1ec1e8d442e463))
+
+* chore(deps): update dependency isort to v5.12.0 (#30)
+
+Co-authored-by: renovate[bot] &lt;29139614+renovate[bot]@users.noreply.github.com&gt; ([`3673aa2`](https://github.com/nakamasato/autodoc/commit/3673aa229107963f48039831f1d566fbcd05fb69))
+
+* chore(deps): update dependency black to v23.3.0 (#34)
+
+Co-authored-by: renovate[bot] &lt;29139614+renovate[bot]@users.noreply.github.com&gt; ([`02eb42b`](https://github.com/nakamasato/autodoc/commit/02eb42b869d5ba0e4409a7061fb42b27189b0ef8))
+
+* chore(deps): update dependency python-dotenv to v0.21.1 (#28)
+
+Co-authored-by: renovate[bot] &lt;29139614+renovate[bot]@users.noreply.github.com&gt; ([`13d4d27`](https://github.com/nakamasato/autodoc/commit/13d4d27562420729f7d49b83390cc545b00fd863))
+
+* chore: enable renovate to automerge (#35) ([`a612696`](https://github.com/nakamasato/autodoc/commit/a612696fd7e1de531bf4e3c6b4a083e0603a6d9c))
+
+* chore: update README.md (#25) ([`cbf9049`](https://github.com/nakamasato/autodoc/commit/cbf904991c14a00f0001e93c4eed2fb382e6bf6b))
+
+* chore: update utils (#23) ([`ce8c5c1`](https://github.com/nakamasato/autodoc/commit/ce8c5c12c9b577807b0a392fb598c54819b82a96))
+
+### Feature
+
+* feat: remove html from autonote package (#24) ([`06256c7`](https://github.com/nakamasato/autodoc/commit/06256c74dcd5b41d20a6cde1a66fcb3a1af665b5))
+
+### Fix
+
+* fix(deps): update dependency atlassian-python-api to v3.41.0 (#67)
+
+Co-authored-by: renovate[bot] &lt;29139614+renovate[bot]@users.noreply.github.com&gt; ([`91aa9b6`](https://github.com/nakamasato/autodoc/commit/91aa9b66d29241c8e15bf934fa561a42fbe60984))
+
+* fix(deps): update dependency atlassian-python-api to v3.40.1 (#64)
+
+Co-authored-by: renovate[bot] &lt;29139614+renovate[bot]@users.noreply.github.com&gt; ([`cc469a2`](https://github.com/nakamasato/autodoc/commit/cc469a2c373462fa7a9ed0fb230dd3b8f6d736b3))
+
+* fix(deps): update dependency atlassian-python-api to v3.40.0 (#61)
+
+Co-authored-by: renovate[bot] &lt;29139614+renovate[bot]@users.noreply.github.com&gt; ([`da0d22f`](https://github.com/nakamasato/autodoc/commit/da0d22fd5a98c2cb11dcb74d6a48aefd9677c23d))
+
+* fix(deps): update dependency atlassian-python-api to v3.39.0 (#53)
+
+Co-authored-by: renovate[bot] &lt;29139614+renovate[bot]@users.noreply.github.com&gt; ([`931efb4`](https://github.com/nakamasato/autodoc/commit/931efb48e0e7df7a0520c036a8d22bb460b3a94b))
+
+* fix(deps): update dependency atlassian-python-api to v3.38.0 (#45)
+
+Co-authored-by: renovate[bot] &lt;29139614+renovate[bot]@users.noreply.github.com&gt; ([`f66f3c2`](https://github.com/nakamasato/autodoc/commit/f66f3c26701b99b2d191a658017cdd76ac9f9fad))
+
+* fix(deps): update dependency atlassian-python-api to v3.37.0 (#39)
+
+Co-authored-by: renovate[bot] &lt;29139614+renovate[bot]@users.noreply.github.com&gt; ([`6812f9c`](https://github.com/nakamasato/autodoc/commit/6812f9c2115115218400dc59335d9b17fa1ad379))
+
+* fix(deps): update dependency atlassian-python-api to v3.36.0 (#33)
+
+Co-authored-by: renovate[bot] &lt;29139614+renovate[bot]@users.noreply.github.com&gt; ([`f1d8750`](https://github.com/nakamasato/autodoc/commit/f1d87505a159937ae9b90d3d11aabd45abc0a9ab))
+
+
+## v0.4.0 (2023-02-04)
+
+### Chore
+
+* chore: fix github actions and test (#19) ([`5a06798`](https://github.com/nakamasato/autodoc/commit/5a067984d9007fa6d3d4cdb8133f420d94f8bb95))
+
+### Documentation
+
+* docs: update readme and examples (#22) ([`2c5bd4d`](https://github.com/nakamasato/autodoc/commit/2c5bd4dca845c6143ef8b1b3520d0a63de85e24d))
+
+### Feature
+
+* feat: enable to specify date in contents with values (notion) (#21) ([`bd375dc`](https://github.com/nakamasato/autodoc/commit/bd375dcaf13cfdaa0318ee3c09559a2da2f91b06))
+
+* feat: enable to create a notion page from a template with dynamic values (#20) ([`503625b`](https://github.com/nakamasato/autodoc/commit/503625bdf865141a43f19fbab327eba6598725c5))
+
+
+## v0.3.0 (2023-02-02)
+
+### Chore
+
+* chore(deps): update dependency black to v23 (#17)
+
+Co-authored-by: renovate[bot] &lt;29139614+renovate[bot]@users.noreply.github.com&gt; ([`745e23a`](https://github.com/nakamasato/autodoc/commit/745e23a638264da2b76c2257a6cd196b369f94fa))
+
+### Feature
+
+* feat: enable to create notion page from template (#18) ([`1147ce7`](https://github.com/nakamasato/autodoc/commit/1147ce79eba32b094391e8f5a3d4a3c3bc944294))
+
+
+## v0.2.3 (2023-01-10)
+
+### Chore
+
+* chore: separate pull request and release workflow (#16) ([`7ddce6b`](https://github.com/nakamasato/autodoc/commit/7ddce6b7e6d161c56877a95157aa8e96bd4a12ae))
+
+
+## v0.2.2 (2023-01-10)
+
+### Chore
+
+* chore: add if condition to install poetry step (#15) ([`5a03107`](https://github.com/nakamasato/autodoc/commit/5a031072037289d5b4e5ab51d93e2ed6075c43c8))
+
+
+## v0.2.1 (2023-01-07)
+
+### Chore
+
+* chore: add cache for poetry installation (#14) ([`92a89c5`](https://github.com/nakamasato/autodoc/commit/92a89c5199f34fe0e64f13c855645e8f2b3a6c53))
+
+
+## v0.2.0 (2023-01-05)
+
+### Feature
+
+* feat: enable to create notion page (#13) ([`ede0ed4`](https://github.com/nakamasato/autodoc/commit/ede0ed43e648f682bae4c262a025e8b4b8935d98))
+
+
+## v0.1.7 (2023-01-05)
+
+### Chore
+
+* chore(deps): update codecov/codecov-action action to v3 (#11)
+
+Co-authored-by: renovate[bot] &lt;29139614+renovate[bot]@users.noreply.github.com&gt; ([`7ea6116`](https://github.com/nakamasato/autodoc/commit/7ea6116013aba3555497855cb0dc257cfcfe4ace))
+
+
+## v0.1.6 (2023-01-05)
+
+### Chore
+
+* chore: add lint (#10) ([`6d824b9`](https://github.com/nakamasato/autodoc/commit/6d824b9765548b52603f8b966b674a0c8f24cdac))
+
+
+## v0.1.5 (2023-01-05)
+
+### Chore
+
+* chore: update ci/cd (#9) ([`b61c2bd`](https://github.com/nakamasato/autodoc/commit/b61c2bdd295c0c83262897035d093835f62b5d21))
+
+
+## v0.1.4 (2023-01-05)
+
+### Build
+
+* build: add PSR as dev dependency (#3) ([`a3ac33b`](https://github.com/nakamasato/autodoc/commit/a3ac33b8a27c75b9dc73899ea81a7942548be36b))
+
+### Chore
+
+* chore(deps): update actions/setup-python action to v4 (#7)
+
+Co-authored-by: renovate[bot] &lt;29139614+renovate[bot]@users.noreply.github.com&gt; ([`cee8bc2`](https://github.com/nakamasato/autodoc/commit/cee8bc22fa0458824ba0682bc9808d469391c188))
+
+* chore(deps): update actions/checkout action to v3 (#6)
+
+Co-authored-by: renovate[bot] &lt;29139614+renovate[bot]@users.noreply.github.com&gt; ([`ac90e1f`](https://github.com/nakamasato/autodoc/commit/ac90e1f8cfe3289392eec276b63d53743d406a03))
+
+* chore: configure Renovate (#5)
+
+Co-authored-by: renovate[bot] &lt;29139614+renovate[bot]@users.noreply.github.com&gt; ([`f927c4d`](https://github.com/nakamasato/autodoc/commit/f927c4d3b5b48819b0df731848738163a1c51ec1))
+
+* chore: add semantic version (#4)
+
+* build: add PSR as dev dependency
+
+* chore: update changelog and pyproject.toml ([`5dd4c26`](https://github.com/nakamasato/autodoc/commit/5dd4c2678c805b4db6ff20f4f40829ce4912533b))
+
+### Unknown
+
+* make package (#2)
+
+* temporary
+
+* restructure package
+
+* docs
+
+* remove dotenv from poetry
+
+* enable to run main.py
+
+* eof
+
+* update
+
+* update
+
+* rename package to autonote
+
+* update ([`a24bf3d`](https://github.com/nakamasato/autodoc/commit/a24bf3d378a5508c6af10314e981438b0e471285))
+
+* add monthly schedule (#1) ([`998c1d7`](https://github.com/nakamasato/autodoc/commit/998c1d7079de5c233fd66e8d2599575cd3df6403))
+
+* init commit ([`fba80b2`](https://github.com/nakamasato/autodoc/commit/fba80b2f808107f1ddc5309753b4c475f0ec78ef))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "autonote"
-version = "0.1.3"
+version = "0.5.0-rc.1+release-prepare"
 description = "Automate taking notes"
 authors = ["Masato Naka"]
 license = "MIT"
@@ -45,6 +45,11 @@ tag_format = "v{version}"
 match = "(main|master)"
 prerelease_token = "rc"
 prerelease = false
+
+[tool.semantic_release.branches.release-]
+match = "(release-*)"
+prerelease_token = "rc"
+prerelease = true
 
 [tool.semantic_release.changelog]
 template_dir = "templates"


### PR DESCRIPTION
- chore: fix typo release.yml (#75)
- chore(deps): update dependency python-semantic-release to v8.0.8 (#76)
- chore: upgrade configuration for semantic-release (#77)
- chore: replace release step with python-semantic-release (#78)
- chore: remove build command (#79)
- chore: update build command (#80)
- 0.5.0-rc.1+release-prepare
