### PR TITLE
chore: specify semantic-release 8.3.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
         run: make install
 
       - name: Python Semantic Release
-        uses: python-semantic-release/python-semantic-release@master
+        uses: python-semantic-release/python-semantic-release@v8.3.0 # fix this version to use Python version 3.12
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/renovate.json
+++ b/renovate.json
@@ -10,5 +10,27 @@
   },
   "ignorePaths": [
     ".tool-versions"
+  ],
+  "packageRules": [
+    {
+      "groupName": "GitHub Actions",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchPackageNames": [
+        "python-semantic-release/python-semantic-release"
+      ],
+      "automerge": false
+    },
+    {
+      "groupName": "GitHub Actions",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchPackageNames": [
+        "python-semantic-release/python-semantic-release"
+      ],
+      "automerge": false
+    }
   ]
 }


### PR DESCRIPTION
# what
- specify semantic-release 8.3.0
- update renovate not to update python-semantic-release

# why

- [8.3.0](https://github.com/python-semantic-release/python-semantic-release/releases/tag/v8.3.0) includes https://github.com/python-semantic-release/python-semantic-release/pull/692, which was reverted later

github actions failed `The currently activated Python version 3.10.13 is not supported by the project (^3.12).`

https://github.com/nakamasato/autonote/actions/runs/8311264018/job/22744703782

https://github.com/python-semantic-release/python-semantic-release/issues/685